### PR TITLE
Migrate to SpeziNetworking 2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "EDFFormat", targets: ["EDFFormat"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking.git", from: "1.0.0")
+        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking.git", from: "2.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "EDFFormat", targets: ["EDFFormat"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking.git", from: "2.0.0")
+        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking.git", from: "2.0.1")
     ],
     targets: [
         .target(

--- a/Sources/EDFFormat/GenericFileWriter.swift
+++ b/Sources/EDFFormat/GenericFileWriter.swift
@@ -244,7 +244,7 @@ public final class GenericFileWriter<S: Sample> {
         case .bdf:
             recordBuffer.reserveCapacity(24 * totalSampleCount)
         }
-        record.encode(to: &recordBuffer, preferredEndianness: .little)
+        record.encode(to: &recordBuffer)
 
         let recordData = recordBuffer.getData(at: 0, length: recordBuffer.readableBytes) ?? .init()
         try fileHandle.write(contentsOf: recordData)
@@ -324,10 +324,10 @@ extension GenericFileWriter {
     }
 
     func encodeHeader(to byteBuffer: inout ByteBuffer) {
-        format.encode(to: &byteBuffer, preferredEndianness: .little)
+        format.encode(to: &byteBuffer)
 
-        fileInformation.subject.encode(to: &byteBuffer, preferredEndianness: .little)
-        fileInformation.recording.encode(to: &byteBuffer, preferredEndianness: .little)
+        fileInformation.subject.encode(to: &byteBuffer)
+        fileInformation.recording.encode(to: &byteBuffer)
 
         let year = Calendar.current.component(.year, from: fileInformation.recording.startDate)
         if year >= 1985 && year <= 2084 {
@@ -354,7 +354,7 @@ extension GenericFileWriter {
         }
 
         byteBuffer.writeEDFAscii(channelCount, length: 4)
-        signals.encode(to: &byteBuffer, preferredEndianness: .little)
+        signals.encode(to: &byteBuffer)
     }
 }
 

--- a/Sources/EDFFormat/Information/FileFormat.swift
+++ b/Sources/EDFFormat/Information/FileFormat.swift
@@ -37,7 +37,7 @@ extension FileFormat: Hashable, Sendable {}
 
 
 extension FileFormat: ByteEncodable {
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         switch self {
         case .edf:
             byteBuffer.writeEDFAscii(".", length: 8)

--- a/Sources/EDFFormat/Information/RecordingIdentification.swift
+++ b/Sources/EDFFormat/Information/RecordingIdentification.swift
@@ -94,7 +94,7 @@ extension RecordingInformation: EDFRepresentable {
 
 
 extension RecordingIdentification: ByteEncodable {
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         switch self {
         case let .unstructured(recording, _):
             byteBuffer.writeEDFAsciiTrimming(recording, length: 80)

--- a/Sources/EDFFormat/Information/SubjectIdentification.swift
+++ b/Sources/EDFFormat/Information/SubjectIdentification.swift
@@ -99,7 +99,7 @@ extension PatientInformation.Sex: EDFRepresentable {
 
 
 extension SubjectIdentification: ByteEncodable {
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         switch self {
         case let .unstructured(subject):
             byteBuffer.writeEDFAsciiTrimming(subject, length: 80)

--- a/Sources/EDFFormat/Signal/Channel.swift
+++ b/Sources/EDFFormat/Signal/Channel.swift
@@ -28,9 +28,9 @@ extension Channel: Hashable, Sendable {}
 
 
 extension Channel: ByteEncodable {
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         for sample in samples {
-            sample.encode(to: &byteBuffer, preferredEndianness: endianness)
+            sample.encode(to: &byteBuffer, endianness: .little)
         }
     }
 }

--- a/Sources/EDFFormat/Signal/DataRecord.swift
+++ b/Sources/EDFFormat/Signal/DataRecord.swift
@@ -27,9 +27,9 @@ public struct DataRecord<S: Sample> {
 extension DataRecord: Hashable, Sendable {}
 
 extension DataRecord: ByteEncodable {
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         for channel in channels {
-            channel.encode(to: &byteBuffer, preferredEndianness: endianness)
+            channel.encode(to: &byteBuffer)
         }
     }
 }

--- a/Sources/EDFFormat/Signal/Sample.swift
+++ b/Sources/EDFFormat/Signal/Sample.swift
@@ -44,7 +44,7 @@ public struct EDFSample {
 
 
 /// A recorded sample.
-public protocol Sample: ByteCodable, Hashable, Sendable {
+public protocol Sample: PrimitiveByteCodable, Hashable, Sendable {
     /// The sample value type (e.g., `Int16`).
     associatedtype Value: BinaryInteger
 
@@ -58,29 +58,29 @@ extension BDFSample: Hashable, Sample {}
 extension EDFSample: Hashable, Sample {}
 
 
-extension BDFSample: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+extension BDFSample: PrimitiveByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
         guard let value = byteBuffer.readInt24(endianness: endianness) else {
             return nil
         }
         self.init(value)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
         byteBuffer.writeInt24(value, endianness: endianness)
     }
 }
 
 
-extension EDFSample: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let value = Int16(from: &byteBuffer, preferredEndianness: endianness) else {
+extension EDFSample: PrimitiveByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        guard let value = Int16(from: &byteBuffer, endianness: endianness) else {
             return nil
         }
         self.init(value)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        value.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer, endianness: Endianness) {
+        value.encode(to: &byteBuffer, endianness: endianness)
     }
 }

--- a/Sources/EDFFormat/Signal/Signal.swift
+++ b/Sources/EDFFormat/Signal/Signal.swift
@@ -108,7 +108,7 @@ extension Signal {
 
 
 extension Array: ByteEncodable where Element == Signal {
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         for header in self {
             byteBuffer.writeEDFAsciiTrimming(header.label.rawValue, length: 16)
         }


### PR DESCRIPTION
# Migrate to SpeziNetworking 2.0

## :recycle: Current situation & Problem
This PR migrates SpeziFileFormats to use the newest release of ByteCoding as part of SpeziNetworking 2.0.


## :gear: Release Notes 
* Migrate to new SpeziNetworking 2.0 release.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
