### PR TITLE
Enabling Strict Concurrency Checking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,15 @@
 // SPDX-License-Identifier: MIT
 //
 
+import class Foundation.ProcessInfo
 import PackageDescription
+
+
+#if swift(<6)
+let swiftConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
+#else
+let swiftConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
+#endif
 
 
 let package = Package(
@@ -24,22 +32,48 @@ let package = Package(
         .library(name: "EDFFormat", targets: ["EDFFormat"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking.git", from: "2.0.1")
-    ],
+        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking.git", from: "2.1.2")
+    ] + swiftLintPackage(),
     targets: [
         .target(
             name: "EDFFormat",
             dependencies: [
                 .product(name: "ByteCoding", package: "SpeziNetworking"),
                 .product(name: "SpeziNumerics", package: "SpeziNetworking")
-            ]
+            ],
+            swiftSettings: [
+                swiftConcurrency
+            ],
+            plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
             name: "EDFFormatTests",
             dependencies: [
                 .product(name: "ByteCoding", package: "SpeziNetworking"),
                 .target(name: "EDFFormat")
-            ]
+            ],
+            swiftSettings: [
+                swiftConcurrency
+            ],
+            plugins: [] + swiftLintPlugin()
         )
     ]
 )
+
+
+func swiftLintPlugin() -> [Target.PluginUsage] {
+    // Fully quit Xcode and open again with `open --env SPEZI_DEVELOPMENT_SWIFTLINT /Applications/Xcode.app`
+    if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
+        [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]
+    } else {
+        []
+    }
+}
+
+func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
+    if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
+        [.package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.1"))]
+    } else {
+        []
+    }
+}

--- a/Sources/EDFFormat/Signal/Signal.swift
+++ b/Sources/EDFFormat/Signal/Signal.swift
@@ -107,7 +107,7 @@ extension Signal {
 }
 
 
-extension Array: ByteEncodable where Element == Signal {
+extension Swift.Array: ByteCoding.ByteEncodable where Element == Signal {
     public func encode(to byteBuffer: inout ByteBuffer) {
         for header in self {
             byteBuffer.writeEDFAsciiTrimming(header.label.rawValue, length: 16)


### PR DESCRIPTION
# Enabling Strict Concurrency Checking

## :recycle: Current situation & Problem
This PR enables strict concurrency checking. We didn't need to resolve any concurrency warnings.


## :gear: Release Notes 
* Enable strict concurrency checking.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
